### PR TITLE
Fix Problem When Running Unit Test With Util, Part 2

### DIFF
--- a/src/cross-space/globalmacros.h
+++ b/src/cross-space/globalmacros.h
@@ -11,6 +11,7 @@
 #define _NVMIX_GLOBALMACROS_H_
 
 
+// 所有 cross-space 中的文件都会引用 globalmacros.h，因为这是个 C 库，不能保证用户态是用 C 还是 C++ 来测。C++ 的代码默认会定义 __cplusplus 宏，因此根据这个对 NVMIX_EXTERN_C_BEGIN 和 NVMIX_EXTERN_C_END 分别定义，防止符号兼容性出问题。可能想到的一种写法是将 #ifdef __cplusplus 写在 #define 中，但这样是非法的，必须使用条件编译的形式。
 #ifdef __cplusplus
 
 #define NVMIX_EXTERN_C_BEGIN \


### PR DESCRIPTION
接 [https://github.com/DavidingPlus/nvmixfs/pull/11](https://github.com/DavidingPlus/nvmixfs/pull/11)。

我自己的问题，宏的使用方法弄错了。

所有 cross-space 中的文件都会引用 globalmacros.h，因为这是个 C 库，不能保证用户态是用 C 还是 C++ 来测。C++ 的代码默认会定义 __cplusplus 宏，因此根据这个对 NVMIX_EXTERN_C_BEGIN 和 NVMIX_EXTERN_C_END 分别定义，防止符号兼容性出问题。可能想到的一种写法是将 #ifdef __cplusplus 写在 #define 中，但这样是非法的，必须使用条件编译的形式。

