### PR TITLE
Fix Bug When Using Vim To Test Nvmixfs

### DIFF
--- a/snippet/MkfsNvmixfs/clear.sh
+++ b/snippet/MkfsNvmixfs/clear.sh
@@ -1,6 +1,12 @@
 set -e
 
-sudo umount /mnt/nvmixfs/
 
-sudo rmmod nvmixfs
+if mountpoint -q /mnt/nvmixfs/; then
+    sudo umount /mnt/nvmixfs/
 
+fi
+
+if lsmod | grep -q "nvmixfs"; then
+    sudo rmmod nvmixfs
+
+fi

--- a/snippet/MkfsNvmixfs/clear.sh
+++ b/snippet/MkfsNvmixfs/clear.sh
@@ -1,3 +1,4 @@
+# 遇到错误立即退出。
 set -e
 
 
@@ -8,5 +9,10 @@ fi
 
 if lsmod | grep -q "nvmixfs"; then
     sudo rmmod nvmixfs
+
+fi
+
+if [[ -d "/mnt/nvmixfs/" ]]; then
+    sudo rm -rf /mnt/nvmixfs/
 
 fi

--- a/snippet/MkfsNvmixfs/clear.sh
+++ b/snippet/MkfsNvmixfs/clear.sh
@@ -1,0 +1,6 @@
+set -e
+
+sudo umount /mnt/nvmixfs/
+
+sudo rmmod nvmixfs
+

--- a/snippet/MkfsNvmixfs/init.sh
+++ b/snippet/MkfsNvmixfs/init.sh
@@ -1,0 +1,11 @@
+# 遇到错误立即退出。
+set -e
+
+./clear.sh
+
+sudo insmod ./build/linux/x86_64/debug/bin/nvmixfs.ko
+
+sudo ./build/linux/x86_64/debug/snippet/mkfs.nvmixfs /dev/sdb2
+
+sudo mount -t nvmixfs /dev/sdb2 /mnt/nvmixfs
+

--- a/snippet/MkfsNvmixfs/init.sh
+++ b/snippet/MkfsNvmixfs/init.sh
@@ -1,7 +1,16 @@
 # 遇到错误立即退出。
 set -e
 
-./clear.sh
+
+if mountpoint -q /mnt/nvmixfs/; then
+    sudo umount /mnt/nvmixfs/
+
+fi
+
+if lsmod | grep -q "nvmixfs"; then
+    sudo rmmod nvmixfs
+
+fi
 
 sudo insmod ./build/linux/x86_64/debug/bin/nvmixfs.ko
 

--- a/snippet/MkfsNvmixfs/init.sh
+++ b/snippet/MkfsNvmixfs/init.sh
@@ -1,20 +1,15 @@
-# 遇到错误立即退出。
 set -e
 
 
-if mountpoint -q /mnt/nvmixfs/; then
-    sudo umount /mnt/nvmixfs/
+CURRENT_DIR="$(dirname "$(realpath "$0")")"
 
-fi
 
-if lsmod | grep -q "nvmixfs"; then
-    sudo rmmod nvmixfs
+$CURRENT_DIR/clear.sh
 
-fi
+sudo mkdir /mnt/nvmixfs/
 
-sudo insmod ./build/linux/x86_64/debug/bin/nvmixfs.ko
+sudo insmod "$CURRENT_DIR/../../build/linux/x86_64/debug/bin/nvmixfs.ko"
 
-sudo ./build/linux/x86_64/debug/snippet/mkfs.nvmixfs /dev/sdb2
+sudo "$CURRENT_DIR/../../build/linux/x86_64/debug/snippet/mkfs.nvmixfs" /dev/sdb2
 
 sudo mount -t nvmixfs /dev/sdb2 /mnt/nvmixfs
-

--- a/snippet/MkfsNvmixfs/main.cpp
+++ b/snippet/MkfsNvmixfs/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char const *argv[])
     msb.m_version.m_minor = NVMIX_CONFIG_VERSION_MINOR;
     msb.m_version.m_alter = NVMIX_CONFIG_VERSION_ALTER;
 
-    msb.m_imap = 0x03;
+    msb.m_imap = 1; // 初始情况下只有根目录。
 
     // zero disk
     memset(buffer, 0, NVMIX_BLOCK_SIZE);

--- a/snippet/MkfsNvmixfs/main.cpp
+++ b/snippet/MkfsNvmixfs/main.cpp
@@ -11,13 +11,13 @@
 
 int main(int argc, char const *argv[])
 {
-    FILE *file;
+    FILE *file = NULL;
     char buffer[NVMIX_BLOCK_SIZE] = {0};
     struct NvmixSuperBlock msb;
     struct NvmixInode rootDirInode;
     struct NvmixInode fileInode;
     struct NvmixDentry fileDentry;
-    int i;
+    int i = 0;
 
     if (2 != argc)
     {
@@ -42,7 +42,8 @@ int main(int argc, char const *argv[])
     msb.m_version.m_minor = NVMIX_CONFIG_VERSION_MINOR;
     msb.m_version.m_alter = NVMIX_CONFIG_VERSION_ALTER;
 
-    msb.m_imap = 1; // 初始情况下只有根目录。
+    // 直接访问块设备就不会走 vfs 这一层了，所以初始化的时候 m_imap 需要考虑 a.txt，写为 3 而不是 1。
+    msb.m_imap = 0x03;
 
     // zero disk
     memset(buffer, 0, NVMIX_BLOCK_SIZE);

--- a/snippet/MkfsNvmixfs/main.cpp
+++ b/snippet/MkfsNvmixfs/main.cpp
@@ -12,9 +12,9 @@
 int main(int argc, char const *argv[])
 {
     FILE *file;
-    char buffer[NVMIX_BLOCK_SIZE];
+    char buffer[NVMIX_BLOCK_SIZE] = {0};
     struct NvmixSuperBlock msb;
-    struct NvmixInode rootInode;
+    struct NvmixInode rootDirInode;
     struct NvmixInode fileInode;
     struct NvmixDentry fileDentry;
     int i;
@@ -44,27 +44,27 @@ int main(int argc, char const *argv[])
 
     msb.m_imap = 0x03;
 
-    /* zero disk  */
+    // zero disk
     memset(buffer, 0, NVMIX_BLOCK_SIZE);
     for (i = 0; i < 128; i++) fwrite(buffer, 1, NVMIX_BLOCK_SIZE, file);
 
     fseek(file, 0, SEEK_SET);
 
-    /* initialize super block */
+    // initialize super block
     fwrite(&msb, sizeof(msb), 1, file);
 
-    /* initialize root inode */
-    memset(&rootInode, 0, sizeof(rootInode));
-    rootInode.m_uid = 0;
-    rootInode.m_gid = 0;
-    rootInode.m_mode = S_IFDIR | 0755;
-    rootInode.m_size = 0;
-    rootInode.m_dataBlockIndex = NVMIX_FIRST_DATA_BLOCK_INDEX;
+    // initialize root inode
+    memset(&rootDirInode, 0, sizeof(rootDirInode));
+    rootDirInode.m_uid = 0;
+    rootDirInode.m_gid = 0;
+    rootDirInode.m_mode = S_IFDIR | 0755;
+    rootDirInode.m_size = 0;
+    rootDirInode.m_dataBlockIndex = NVMIX_FIRST_DATA_BLOCK_INDEX;
 
     fseek(file, NVMIX_INODE_BLOCK_INDEX * NVMIX_BLOCK_SIZE, SEEK_SET);
-    fwrite(&rootInode, sizeof(rootInode), 1, file);
+    fwrite(&rootDirInode, sizeof(rootDirInode), 1, file);
 
-    /* initialize new inode */
+    // initialize new inode
     memset(&fileInode, 0, sizeof(fileInode));
     fileInode.m_uid = 0;
     fileInode.m_gid = 0;
@@ -73,7 +73,7 @@ int main(int argc, char const *argv[])
     fileInode.m_dataBlockIndex = NVMIX_FIRST_DATA_BLOCK_INDEX + 1;
     fwrite(&fileInode, sizeof(fileInode), 1, file);
 
-    /* add dentry information */
+    // add dentry information
     memset(&fileDentry, 0, sizeof(fileDentry));
     fileDentry.m_ino = 1;
     memcpy(fileDentry.m_name, "a.txt", 5);

--- a/src/kernel/dir.c
+++ b/src/kernel/dir.c
@@ -51,7 +51,7 @@ int nvmixReaddir(struct file *pParentDirFile, struct dir_context *pCtx)
     {
         pr_err("nvmixfs: could not read data block.\n");
 
-        res = -ENOMEM;
+        res = -EIO;
         goto ERR;
     }
 

--- a/src/kernel/file.c
+++ b/src/kernel/file.c
@@ -21,4 +21,5 @@ struct file_operations nvmixFileFileOps = {
     .write_iter = generic_file_write_iter,
     .mmap = generic_file_mmap,
     .llseek = generic_file_llseek,
+    .fsync = generic_file_fsync,
 };

--- a/src/kernel/file.c
+++ b/src/kernel/file.c
@@ -21,5 +21,7 @@ struct file_operations nvmixFileFileOps = {
     .write_iter = generic_file_write_iter,
     .mmap = generic_file_mmap,
     .llseek = generic_file_llseek,
+    // fsync 的作用是将文件在内存中的修改（包括数据和元数据）强制同步到物理存储设备（如磁盘），确保数据持久化。
+    // 另一个命名相似的接口 fasync，用于管理文件的异步通知机制，二者完全不同。本文件系统暂不考虑。
     .fsync = generic_file_fsync,
 };

--- a/src/kernel/fs.c
+++ b/src/kernel/fs.c
@@ -93,6 +93,7 @@ int nvmixFillSuper(struct super_block *pSb, void *pData, int silent)
     struct dentry *pRootDirDentry = NULL;
     int res = 0;
 
+
     // 为辅助结构 NvmixSuperBlockHelper 分配内存。
     pNsbh = kzalloc(sizeof(struct NvmixSuperBlockHelper), GFP_KERNEL);
     if (!pNsbh)
@@ -205,6 +206,7 @@ void nvmixPutSuper(struct super_block *pSb)
 struct inode *nvmixAllocInode(struct super_block *pSb)
 {
     struct NvmixInodeHelper *pNih = NULL;
+
 
     // kzalloc() 与 kmalloc() 的区别在于 kzalloc() 会把动态开辟的内存的内容置 0。
     pNih = kzalloc(sizeof(struct NvmixInodeHelper), GFP_KERNEL);

--- a/src/kernel/fs.c
+++ b/src/kernel/fs.c
@@ -121,7 +121,7 @@ int nvmixFillSuper(struct super_block *pSb, void *pData, int silent)
     {
         pr_err("nvmixfs: could not read super block.\n");
 
-        res = -ENOMEM;
+        res = -EIO;
         goto ERR;
     }
     pNsb = (struct NvmixSuperBlock *)(pBh->b_data);
@@ -262,7 +262,7 @@ int nvmixWriteInode(struct inode *pInode, struct writeback_control *pWbc)
     {
         pr_err("nvmixfs: could not read inode block.\n");
 
-        res = -ENOMEM;
+        res = -EIO;
         goto ERR;
     }
 

--- a/src/kernel/fs.c
+++ b/src/kernel/fs.c
@@ -139,13 +139,6 @@ int nvmixFillSuper(struct super_block *pSb, void *pData, int silent)
     pSb->s_magic = NVMIX_MAGIC_NUMBER;
     pSb->s_op = &nvmixSuperOps;
 
-    // 磁盘上的 NvmixSuperBlock 元数据向内存辅助结构 NvmixSuperBlockHelper 传递信息。
-    pNsbh->m_imap = pNsb->m_imap;
-
-    pNsbh->m_version.m_major = pNsb->m_version.m_major;
-    pNsbh->m_version.m_minor = pNsb->m_version.m_minor;
-    pNsbh->m_version.m_alter = pNsb->m_version.m_alter;
-
     // 分配根目录的 inode 和 dentry。
     pRootDirInode = nvmixIget(pSb, NVMIX_ROOT_DIR_INODE_NUMBER);
     if (!pRootDirInode)

--- a/src/kernel/fs.h
+++ b/src/kernel/fs.h
@@ -16,24 +16,17 @@
 #include <linux/buffer_head.h>
 
 
+/**
+ * @struct NvmixSuperBlockHelper
+ * @brief 内核 vfs 通过 NvmixSuperBlockHelper 结构的 m_pBh 缓存区指针与磁盘上的 NvmixSuperBlock 建立联系。
+ * @details 这个指针在 fill_super() 函数中被初始化，然后就没有释放过。记录这个指针是为了在操作文件系统的时候能够及时更新超级块区的信息。这是不可避免的。包装一层是为了语义和美观。
+ */
 struct NvmixSuperBlockHelper
 {
     /**
      * @brief 磁盘上超级块区的缓冲区指针。
-     * @details 这个指针在 fill_super() 函数中被初始化，然后就没有释放过。记录这个指针是为了在操作文件系统的时候能够及时更新超级块区的信息。这是不可避免的。
      */
     struct buffer_head *m_pBh;
-
-    /**
-     * @brief 管理 inode 分配状态的位图信息。
-     * @details 同 defs.h 中 NvmixSuperBlock 的 m_imap。
-     */
-    unsigned long m_imap;
-
-    /**
-     * @brief 文件系统的版本号。
-     */
-    struct NvmixVersion m_version;
 };
 
 

--- a/src/kernel/inode.c
+++ b/src/kernel/inode.c
@@ -26,6 +26,7 @@ struct inode_operations nvmixDirInodeOps = {
     .lookup = nvmixLookup,
     .create = nvmixCreate,
     .unlink = nvmixUnlink,
+    // TODO 添加创建目录 mkdir() 和删除目录 rmdir() 支持。
 };
 
 // 由进程打开的文件（用 file 结构描述）的操作接口。

--- a/src/kernel/inode.c
+++ b/src/kernel/inode.c
@@ -25,8 +25,7 @@ struct inode_operations nvmixFileInodeOps = {
 struct inode_operations nvmixDirInodeOps = {
     .lookup = nvmixLookup,
     .create = nvmixCreate,
-    // TODO simple_unlink() 是内核提供的通用函数，用于处理简单的文件删除操作。但它不会自动触发元数据同步到磁盘上，如目录 inode 的修改时间、目录项删除的持久化。后续应再包装一层。
-    .unlink = simple_unlink,
+    .unlink = nvmixUnlink,
 };
 
 // 由进程打开的文件（用 file 结构描述）的操作接口。
@@ -139,6 +138,13 @@ int nvmixCreate(struct inode *pParentDirInode, struct dentry *pDentry, umode_t m
 
 ERR:
     return res;
+}
+
+// 参数含义同样同 nvmixCreate()。
+int nvmixUnlink(struct inode *pParentDirInode, struct dentry *pDentry)
+{
+    // TODO simple_unlink() 是内核提供的通用函数，用于处理简单的文件删除操作。但它不会自动触发元数据同步到磁盘上，如目录 inode 的修改时间、目录项删除的持久化。后续应再包装一层。
+    return simple_unlink(pParentDirInode, pDentry);
 }
 
 

--- a/src/kernel/inode.c
+++ b/src/kernel/inode.c
@@ -188,11 +188,12 @@ int nvmixUnlink(struct inode *pParentDirInode, struct dentry *pDentry)
 
     mark_buffer_dirty(pBh);
 
+
     // 既然删除了 inode，超级块的 m_imap 位图信息需要更新，否则空占 inode。inode 区的内容倒不需要清空，新创建的时候覆盖即可。
     // 磁盘上超级块区的缓冲区指针一直存在于内存中，被 NvmixSuperBlockHelper 维护，不需要手动创建和释放。
     pNsbh = (struct NvmixSuperBlockHelper *)(pSb->s_fs_info);
 
-    test_and_clear_bit(pNd->m_ino, &pNsbh->m_imap);
+    test_and_clear_bit(pInode->i_ino, &pNsbh->m_imap);
 
     pr_info("nvmixfs: m_imap %ld\n", pNsbh->m_imap);
 
@@ -241,6 +242,9 @@ struct inode *nvmixNewInode(struct inode *pParentDirInode)
     test_and_set_bit(index, &pNsbh->m_imap);
     // 标记缓冲区为脏，表示内容已被修改，需要写回磁盘。
     mark_buffer_dirty(pNsbh->m_pBh);
+
+    pr_info("nvmixfs: m_imap in nvmixNewInode(): %ld\n", pNsbh->m_imap);
+
 
     pInode = new_inode(pSb); // 此函数创建新的 inode 结构，并关联到文件系统的超级块。
 

--- a/src/kernel/inode.c
+++ b/src/kernel/inode.c
@@ -195,7 +195,7 @@ int nvmixUnlink(struct inode *pParentDirInode, struct dentry *pDentry)
 
     test_and_clear_bit(pInode->i_ino, &pNsbh->m_imap);
 
-    pr_info("nvmixfs: m_imap %ld\n", pNsbh->m_imap);
+    pr_info("nvmixfs: m_imap in nvmixUnlink(): %ld\n", pNsbh->m_imap);
 
     mark_buffer_dirty(pNsbh->m_pBh);
 

--- a/src/kernel/inode.c
+++ b/src/kernel/inode.c
@@ -25,6 +25,8 @@ struct inode_operations nvmixFileInodeOps = {
 struct inode_operations nvmixDirInodeOps = {
     .lookup = nvmixLookup,
     .create = nvmixCreate,
+    // TODO simple_unlink() 是内核提供的通用函数，用于处理简单的文件删除操作。但它不会自动触发元数据同步到磁盘上，如目录 inode 的修改时间、目录项删除的持久化。后续应再包装一层。
+    .unlink = simple_unlink,
 };
 
 // 由进程打开的文件（用 file 结构描述）的操作接口。

--- a/src/kernel/inode.c
+++ b/src/kernel/inode.c
@@ -149,6 +149,7 @@ int nvmixUnlink(struct inode *pParentDirInode, struct dentry *pDentry)
     struct super_block *pSb = NULL;
     struct NvmixDentry *pNd = NULL;
     struct NvmixSuperBlockHelper *pNsbh = NULL;
+    struct NvmixSuperBlock *pNsb = NULL;
     int i = 0;
     int res = 0;
 
@@ -162,7 +163,6 @@ int nvmixUnlink(struct inode *pParentDirInode, struct dentry *pDentry)
 
     // 将磁盘上父目录的目录项数组读到缓存中。
     pNih = NVMIX_I(pParentDirInode);
-
     pSb = pParentDirInode->i_sb;
 
     pBh = sb_bread(pSb, pNih->m_dataBlockIndex);
@@ -192,10 +192,11 @@ int nvmixUnlink(struct inode *pParentDirInode, struct dentry *pDentry)
     // 既然删除了 inode，超级块的 m_imap 位图信息需要更新，否则空占 inode。inode 区的内容倒不需要清空，新创建的时候覆盖即可。
     // 磁盘上超级块区的缓冲区指针一直存在于内存中，被 NvmixSuperBlockHelper 维护，不需要手动创建和释放。
     pNsbh = (struct NvmixSuperBlockHelper *)(pSb->s_fs_info);
+    pNsb = (struct NvmixSuperBlock *)(pNsbh->m_pBh->b_data);
 
-    test_and_clear_bit(pInode->i_ino, &pNsbh->m_imap);
+    test_and_clear_bit(pInode->i_ino, &pNsb->m_imap);
 
-    pr_info("nvmixfs: m_imap in nvmixUnlink(): %ld\n", pNsbh->m_imap);
+    pr_info("nvmixfs: m_imap in nvmixUnlink(): %ld\n", pNsb->m_imap);
 
     mark_buffer_dirty(pNsbh->m_pBh);
 
@@ -222,15 +223,17 @@ struct inode *nvmixNewInode(struct inode *pParentDirInode)
 {
     struct super_block *pSb = NULL;
     struct NvmixSuperBlockHelper *pNsbh = NULL;
+    struct NvmixSuperBlock *pNsb = NULL;
     struct inode *pInode = NULL;
     unsigned long index = 0;
 
 
     pSb = pParentDirInode->i_sb;
-    pNsbh = (struct NvmixSuperBlockHelper *)(pSb->s_fs_info); // 含义解释见 fs.c。
+    pNsbh = (struct NvmixSuperBlockHelper *)(pSb->s_fs_info); // pSb->s_fs_info 含义解释见 fs.c。
+    pNsb = (struct NvmixSuperBlock *)(pNsbh->m_pBh->b_data);
 
     // find_first_zero_bit() 是内核提供的一个位图操作函数，其作用是从给定的位图中查找第一个值为 0 的位，即未使用的空闲资源。m_imap 是我们自己定义的管理 inode 分配状态的位图信息，类型是 unsigned long，8 个字节，64 位。对本文件系统而言，使用低 32 位，每一位用于标识分配状态。
-    index = find_first_zero_bit(&pNsbh->m_imap, NVMIX_MAX_INODE_NUM);
+    index = find_first_zero_bit(&pNsb->m_imap, NVMIX_MAX_INODE_NUM);
     if (NVMIX_MAX_INODE_NUM == index)
     {
         pr_err("nvmixfs: no space left in imap.\n");
@@ -239,11 +242,11 @@ struct inode *nvmixNewInode(struct inode *pParentDirInode)
     }
 
     // 原子性地测试并设置位图中的目标位，维护 m_imap 状态。
-    test_and_set_bit(index, &pNsbh->m_imap);
+    test_and_set_bit(index, &pNsb->m_imap);
     // 标记缓冲区为脏，表示内容已被修改，需要写回磁盘。
     mark_buffer_dirty(pNsbh->m_pBh);
 
-    pr_info("nvmixfs: m_imap in nvmixNewInode(): %ld\n", pNsbh->m_imap);
+    pr_info("nvmixfs: m_imap in nvmixNewInode(): %ld\n", pNsb->m_imap);
 
 
     pInode = new_inode(pSb); // 此函数创建新的 inode 结构，并关联到文件系统的超级块。

--- a/src/kernel/inode.h
+++ b/src/kernel/inode.h
@@ -45,5 +45,7 @@ struct dentry *nvmixLookup(struct inode *, struct dentry *, unsigned int);
 
 int nvmixCreate(struct inode *, struct dentry *, umode_t, bool);
 
+int nvmixUnlink(struct inode *, struct dentry *);
+
 
 #endif


### PR DESCRIPTION
接 issue：[https://github.com/DavidingPlus/nvmixfs/issues/15](https://github.com/DavidingPlus/nvmixfs/issues/15)。

issue 中的两个问题总结一下就是需要实现 nvmixUnlink 的逻辑。

当删除一个文件的时候，需要做两件事情。第一，由于是在某个目录下删除该文件，需要更新当前目录的目录项 NvmixDentry 数组，重置删除文件的那一项。第二，删除了文件还需要更新 NvmixSuperBlock 结构的 m_imap 位图信息。

说到第二点，在参考 [minfs](https://github.com/linux-kernel-labs/linux/blob/master/tools/labs/templates/filesystems/minfs/kernel/minfs.c) 时发现它一直在修改内存上 minfs_sb_info 中的 imap，没有找到代码进行了磁盘上超级块的同步，我觉得这样是不合理的，既然持久性存储了超级块缓存区的指针 sbh，那么需要及时刷盘啊，而不是只修改内存里的数据，否则重启后重新加载内核模块时 fill_super 的时候读取的又是旧值，这样会出大问题的。因此在我的设计中进行了修改，使用 NvmixSuperBlockHelper 对 struct buffer_head *m_pBh 做了包装，为了语义和美观。

目前测试情况来看，创建文件、删除文件、修改文件（使用 echo 或 vim，vim 会创建中间文件，很好的帮我测试了一波）的功能基本没有什么问题。

创建目录、删除目录的功能后续再做。

