### PR TITLE
Added mkdir And rmdir For nvmixDirInodeOps

### DIFF
--- a/src/kernel/fs.c
+++ b/src/kernel/fs.c
@@ -350,7 +350,12 @@ struct inode *nvmixIget(struct super_block *pSb, unsigned long ino)
     pInode->i_mapping->a_ops = &nvmixAops;
 
     // 根据 inode 是文件还是目录进行不同操作的注册。
-    if (S_ISDIR(pInode->i_mode))
+    if (S_ISREG(pInode->i_mode))
+    {
+        pInode->i_fop = &nvmixFileFileOps;
+        pInode->i_op = &nvmixFileInodeOps;
+    }
+    else if (S_ISDIR(pInode->i_mode))
     {
         pInode->i_fop = &nvmixDirFileOps;
         pInode->i_op = &nvmixDirInodeOps;
@@ -358,11 +363,6 @@ struct inode *nvmixIget(struct super_block *pSb, unsigned long ino)
         // inode 的硬链接个数 i_nlink 默认为 1。但对目录应为 2。例如新建目录 temp，两个硬链接分别为 temp 目录的 . 和父目录的 temp。
         // 硬链接与原始文件共享相同的 inode（索引节点），即两者指向磁盘上的同一块数据。删除原始文件后，只要存在至少一个硬链接，文件数据仍可通过其他硬链接访问。
         inc_nlink(pInode);
-    }
-    else if (S_ISREG(pInode->i_mode))
-    {
-        pInode->i_fop = &nvmixFileFileOps;
-        pInode->i_op = &nvmixFileInodeOps;
     }
     else
     {

--- a/src/kernel/inode.c
+++ b/src/kernel/inode.c
@@ -30,7 +30,8 @@ struct inode_operations nvmixDirInodeOps = {
     .lookup = nvmixLookup,
     .create = nvmixCreate,
     .unlink = nvmixUnlink,
-    // TODO 添加创建目录 mkdir() 和删除目录 rmdir() 支持。
+    .mkdir = nvmixMkdir,
+    .rmdir = nvmixRmdir,
 };
 
 extern struct file_operations nvmixFileFileOps;
@@ -236,6 +237,20 @@ ERR:
 
 
     return res;
+}
+
+int nvmixMkdir(struct inode *pParentDirInode, struct dentry *pDentry, umode_t mode)
+{
+    // TODO
+
+    return 0;
+}
+
+int nvmixRmdir(struct inode *pParentDirInode, struct dentry *pDentry)
+{
+    // TODO
+
+    return 0;
 }
 
 

--- a/src/kernel/inode.c
+++ b/src/kernel/inode.c
@@ -69,6 +69,17 @@ static int nvmixUpdateParentDirDentry(struct dentry *pDentry, struct inode *pIno
  */
 static struct NvmixDentry *nvmixFindDentry(struct dentry *pDentry, struct buffer_head **ppBh);
 
+/**
+ * @brief 在父目录中创建新文件或目录的节点。
+ * @param pParentDirInode 父目录的 inode 指针。
+ * @param pDentry 新创建的节点的 dentry 指针。
+ * @param mode 创建模式参数。
+ * @param excl 独占创建标志，若设置为 true 要求目标必须不存在。暂未用到。
+ * @return 成功返回 0，失败返回非 0。
+ * @details 接口的参数逆天。pParentDirInode 是父目录的 inode 节点，在函数里我需要手动创建新的 vfs inode。而 pDentry 却是新 inode 节点对应的 dentry 对象，内核帮我创建好了。很容易误解为父目录的 dentry，我们需要自己手动创建 dentry，但是内核似乎并没有这种函数。
+ */
+static int nvmixMknod(struct inode *pParentDirInode, struct dentry *pDentry, umode_t mode, bool excl);
+
 
 struct dentry *nvmixLookup(struct inode *pParentDirInode, struct dentry *pDentry, unsigned int flags)
 {
@@ -116,49 +127,18 @@ struct dentry *nvmixLookup(struct inode *pParentDirInode, struct dentry *pDentry
 
 int nvmixCreate(struct inode *pParentDirInode, struct dentry *pDentry, umode_t mode, bool excl)
 {
-    int res = 0;
-    struct inode *pInode = NULL;
-    struct NvmixInodeHelper *pNih = NULL;
+    int res;
 
 
-    pInode = nvmixNewInode(pParentDirInode);
-    if (!pInode)
-    {
-        pr_err("nvmixfs: error when allocating a new inode.\n");
-
-        res = -ENOMEM;
-        goto ERR;
-    }
-
-    pInode->i_mode = mode | S_IFREG;
-
-    // 参考 ext4_create()，对这些操作做了注册。
-    pInode->i_op = &nvmixFileInodeOps;
-    pInode->i_fop = &nvmixFileFileOps;
-    pInode->i_mapping->a_ops = &nvmixAops;
-
-    pNih = NVMIX_I(pInode);
-    pNih->m_dataBlockIndex = NVMIX_FIRST_DATA_BLOCK_INDEX + pInode->i_ino;
-
-    // 将新 inode 关联到父目录的目录项 dentry 中，会维护并修改父目录项的一些信息。与下面的 d_instantiate() 作用不同，注意区分。
-    // 注意此 pDentry 是 pInode 对应的 pDentry，而非父目录的 dentry，前面提到过。
-    res = nvmixUpdateParentDirDentry(pDentry, pInode);
+    res = nvmixMknod(pParentDirInode, pDentry, mode | S_IFREG, excl);
     if (0 != res)
     {
-        // 减少 inode 的硬链接计数。
-        inode_dec_link_count(pInode);
-        // 释放 inode 的引用计数。
-        iput(pInode);
+        pr_info("nvmixfs: failed to create new file.\n");
 
         goto ERR;
     }
 
-    // dentry 作用是关联 inode 和文件名。d_instantiate() 将 dentry 与 inode 绑定，使文件名正确指向文件。
-    d_instantiate(pDentry, pInode);
-    // 标记 inode 为脏，表示其元数据（如权限、大小）或数据已修改，需后续同步到磁盘。
-    mark_inode_dirty(pInode);
-
-    pr_info("nvmixfs: new file inode created successfully, ino = %lu\n", pInode->i_ino);
+    pr_info("nvmixfs: created new file successfully.\n");
 
 
 ERR:
@@ -243,44 +223,18 @@ ERR:
 
 int nvmixMkdir(struct inode *pParentDirInode, struct dentry *pDentry, umode_t mode)
 {
-    int res = 0;
-    struct inode *pInode = NULL;
-    struct NvmixInodeHelper *pNih = NULL;
+    int res;
 
 
-    pInode = nvmixNewInode(pParentDirInode);
-    if (!pInode)
-    {
-        pr_err("nvmixfs: error when allocating a new inode.\n");
-
-        res = -ENOMEM;
-        goto ERR;
-    }
-
-    pInode->i_mode = mode | S_IFDIR;
-
-    pInode->i_op = &nvmixDirInodeOps;
-    pInode->i_fop = &nvmixDirFileOps;
-    pInode->i_mapping->a_ops = &nvmixAops;
-
-    inc_nlink(pInode);
-
-    pNih = NVMIX_I(pInode);
-    pNih->m_dataBlockIndex = NVMIX_FIRST_DATA_BLOCK_INDEX + pInode->i_ino;
-
-    res = nvmixUpdateParentDirDentry(pDentry, pInode);
+    res = nvmixMknod(pParentDirInode, pDentry, mode | S_IFDIR, 0);
     if (0 != res)
     {
-        inode_dec_link_count(pInode);
-        iput(pInode);
+        pr_info("nvmixfs: failed to create new directory.\n");
 
         goto ERR;
     }
 
-    d_instantiate(pDentry, pInode);
-    mark_inode_dirty(pInode);
-
-    pr_info("nvmixfs: new file inode created successfully, ino = %lu\n", pInode->i_ino);
+    pr_info("nvmixfs: created new directory successfully.\n");
 
 
 ERR:
@@ -449,4 +403,72 @@ struct NvmixDentry *nvmixFindDentry(struct dentry *pDentry, struct buffer_head *
 // 注意，这里一定不能释放 pBh，因为返回的 struct NvmixDentry * 依赖于 pBh 缓冲区的存在。如果释放了，传递出去以后就会内存泄露。nvmixFindDentry() 作为唯一被 nvmixLookup() 调用的工具函数，nvmixLookup() 需要用到 struct NvmixDentry * 指针，因此需要需要想办法将 pBh 传递出去。一种合适的方法就是使用 pBh 的指针，即二级指针 struct buffer_head **。至于 pBh 的释放留到 nvmixLookup() 中。
 ERR:
     return pRes;
+}
+
+int nvmixMknod(struct inode *pParentDirInode, struct dentry *pDentry, umode_t mode, bool excl)
+{
+    int res = 0;
+    struct inode *pInode = NULL;
+    struct NvmixInodeHelper *pNih = NULL;
+
+
+    pInode = nvmixNewInode(pParentDirInode);
+    if (!pInode)
+    {
+        pr_err("nvmixfs: error when allocating a new inode.\n");
+
+        res = -ENOMEM;
+        goto ERR;
+    }
+
+    pInode->i_mode = mode;
+
+    // 参考 ext4_create()，对以下操作做了注册。注意对应文件和目录分别处理。
+    pInode->i_mapping->a_ops = &nvmixAops;
+
+    if (S_ISREG(pInode->i_mode))
+    {
+        pInode->i_fop = &nvmixFileFileOps;
+        pInode->i_op = &nvmixFileInodeOps;
+    }
+    else if (S_ISDIR(pInode->i_mode))
+    {
+        pInode->i_fop = &nvmixDirFileOps;
+        pInode->i_op = &nvmixDirInodeOps;
+
+        // 见 fs.c 的 nvmixIget() 函数注释。
+        inc_nlink(pInode);
+    }
+    else
+    {
+        // 非普通文件或目录，暂不考虑。
+    }
+
+
+    pNih = NVMIX_I(pInode);
+    pNih->m_dataBlockIndex = NVMIX_FIRST_DATA_BLOCK_INDEX + pInode->i_ino;
+
+    // 将新 inode 关联到父目录的目录项 dentry 中，会维护并修改父目录项的一些信息。与下面的 d_instantiate() 作用不同，注意区分。
+    // 注意此 pDentry 是 pInode 对应的 pDentry，而非父目录的 dentry，前面提到过。
+    res = nvmixUpdateParentDirDentry(pDentry, pInode);
+    if (0 != res)
+    {
+        // 减少 inode 的硬链接计数。
+        inode_dec_link_count(pInode);
+        // 释放 inode 的引用计数。
+        iput(pInode);
+
+        goto ERR;
+    }
+
+    // dentry 作用是关联 inode 和文件名。d_instantiate() 将 dentry 与 inode 绑定，使文件名正确指向文件。
+    d_instantiate(pDentry, pInode);
+    // 标记 inode 为脏，表示其元数据（如权限、大小）或数据已修改，需后续同步到磁盘。
+    mark_inode_dirty(pInode);
+
+    pr_info("nvmixfs: created new inode successfully, ino = %lu\n", pInode->i_ino);
+
+
+ERR:
+    return res;
 }

--- a/src/kernel/inode.h
+++ b/src/kernel/inode.h
@@ -57,7 +57,6 @@ struct dentry *nvmixLookup(struct inode *pParentDirInode, struct dentry *pDentry
  * @param mode 创建模式参数。
  * @param excl 独占创建标志，若设置为 true 要求目标必须不存在。暂未用到。
  * @return 成功返回 0，失败返回非 0。
- * @details 接口的参数逆天。pParentDirInode 是父目录的 inode 节点，在函数里我需要手动创建新的 vfs inode。而 pDentry 却是新 inode 节点对应的 dentry 对象，内核帮我创建好了。很容易误解为父目录的 dentry，我们需要自己手动创建 dentry，但是内核似乎并没有这种函数。
  */
 int nvmixCreate(struct inode *pParentDirInode, struct dentry *pDentry, umode_t mode, bool excl);
 

--- a/src/kernel/inode.h
+++ b/src/kernel/inode.h
@@ -69,5 +69,22 @@ int nvmixCreate(struct inode *pParentDirInode, struct dentry *pDentry, umode_t m
  */
 int nvmixUnlink(struct inode *pParentDirInode, struct dentry *pDentry);
 
+/**
+ * @brief 在父目录中创建新目录。注册目录 inode 操作接口的 mkdir 函数。
+ * @param pParentDirInode 父目录的 inode 指针。
+ * @param pDentry 新创建的目录的 dentry 指针。
+ * @param mode 创建模式参数。
+ * @return 成功返回 0，失败返回非 0。
+ */
+int nvmixMkdir(struct inode *pParentDirInode, struct dentry *pDentry, umode_t mode);
+
+/**
+ * @brief 在父目录中删除指定目录。注册目录 inode 操作接口的 rmdir 函数。
+ * @param pParentDirInode 父目录的 inode 指针。
+ * @param pDentry 要删除的目录的 dentry 指针。
+ * @return 成功返回 0，失败返回非 0。
+ */
+int nvmixRmdir(struct inode *pParentDirInode, struct dentry *pDentry);
+
 
 #endif


### PR DESCRIPTION
接 issue [https://github.com/DavidingPlus/nvmixfs/issues/17](https://github.com/DavidingPlus/nvmixfs/issues/17)。

为目录 inode 的操作接口添加创建目录 mkdir 和删除目录 rmdir 支持。

其中使用 nvmixMknod 做了代码复用。

