### PR TITLE
Fix Bug That FileSystem Occurs Unexpected Crash When Running `ls`

### DIFF
--- a/src/kernel/inode.c
+++ b/src/kernel/inode.c
@@ -187,8 +187,6 @@ int nvmixUnlink(struct inode *pParentDirInode, struct dentry *pDentry)
         {
             memset(pNd->m_name, 0, NVMIX_MAX_NAME_LENGTH);
             pNd->m_ino = 0;
-
-            break;
         }
     }
 
@@ -411,8 +409,7 @@ struct NvmixDentry *nvmixFindDentry(struct dentry *pDentry, struct buffer_head *
     for (i = 0; i < NVMIX_MAX_ENTRY_NUM; ++i)
     {
         pNd = (struct NvmixDentry *)(pBh->b_data) + i;
-
-        if ((0 != pNd->m_ino) && (pNd->m_ino == pDentry->d_inode->i_ino) && (0 == strcmp(pNd->m_name, pDentry->d_name.name)))
+        if ((0 != pNd->m_ino) && (0 == strcmp(pNd->m_name, pDentry->d_name.name)))
         {
             pr_info("nvmixfs: found entry %s on position: %d\n", pNd->m_name, i);
 

--- a/src/kernel/inode.c
+++ b/src/kernel/inode.c
@@ -183,10 +183,13 @@ int nvmixUnlink(struct inode *pParentDirInode, struct dentry *pDentry)
     {
         pNd = (struct NvmixDentry *)(pBh->b_data) + i;
 
+        // 留意 nvmixFindDentry() 中类似的部分，那里不能判断 pNd->m_ino == pInode->i_ino。这里可以，因为这里的 pDentry 与 pInode 已绑定好，是完整的。
         if ((0 != pNd->m_ino) && (pNd->m_ino == pInode->i_ino) && (0 == strcmp(pNd->m_name, pDentry->d_name.name)))
         {
             memset(pNd->m_name, 0, NVMIX_MAX_NAME_LENGTH);
             pNd->m_ino = 0;
+
+            break;
         }
     }
 
@@ -409,6 +412,8 @@ struct NvmixDentry *nvmixFindDentry(struct dentry *pDentry, struct buffer_head *
     for (i = 0; i < NVMIX_MAX_ENTRY_NUM; ++i)
     {
         pNd = (struct NvmixDentry *)(pBh->b_data) + i;
+
+        // 注意这个地方 pDentry 的语义。nvmixFindDentry() 在 nvmixLookup() 中使用，目的是给定目标 pDentry 找到磁盘的 NvmixDentry 结构。读 nvmixLookup() 的代码可知，此时 pDentry 尚未与 pInode 绑定，只有 pDentry->d_name 有值，pDentry->d_inode 是空指针 NULL，因此不能判断 pNd->m_ino == pDentry->d_inode->i_ino，否则会指针内存泄漏。切记！切记！
         if ((0 != pNd->m_ino) && (0 == strcmp(pNd->m_name, pDentry->d_name.name)))
         {
             pr_info("nvmixfs: found entry %s on position: %d\n", pNd->m_name, i);


### PR DESCRIPTION
接 issue [https://github.com/DavidingPlus/nvmixfs/issues/21](https://github.com/DavidingPlus/nvmixfs/issues/21)。

问题出在函数 nvmixFindDentry 中。

注意这个地方 pDentry 的语义。nvmixFindDentry() 在 nvmixLookup() 中使用，目的是给定目标 pDentry 找到磁盘的 NvmixDentry 结构。读 nvmixLookup() 的代码可知，此时 pDentry 尚未与 pInode 绑定，只有 pDentry->d_name 有值，pDentry->d_inode 是空指针 NULL，因此不能判断 pNd->m_ino == pDentry->d_inode->i_ino，否则会指针内存泄漏。切记！切记！

![image](https://github.com/user-attachments/assets/fb1824fe-482a-4531-a266-7f8367870912)

而类似代码的 nvmixUnlink 则没有这个问题，注意二者的语义以及区别。

![image](https://github.com/user-attachments/assets/18da9b7a-7abd-429e-a9dc-9e699975187a)

